### PR TITLE
Specify minimum emacs version

### DIFF
--- a/mermaid-ts-mode.el
+++ b/mermaid-ts-mode.el
@@ -5,6 +5,7 @@
 ;; Author: Jonathan Hope <jhope@theflatfield.net>
 ;; Version: 1.0
 ;; Keywords: mermaid
+;; Package-Requires: ((emacs "29.1"))
 
 ;;; Commentary:
 


### PR DESCRIPTION
tree-sitter is supported since Emacs 29.1